### PR TITLE
[feat] SearchResultActivity / 서버 에러 해결 (#101)

### DIFF
--- a/core/src/main/java/com/photosurfer/android/core/util/KeyBoardUtil.kt
+++ b/core/src/main/java/com/photosurfer/android/core/util/KeyBoardUtil.kt
@@ -2,6 +2,7 @@ package com.photosurfer.android.core.util
 
 import android.app.Activity
 import android.content.Context
+import android.view.View
 import android.view.inputmethod.InputMethodManager
 
 object KeyBoardUtil {
@@ -14,11 +15,10 @@ object KeyBoardUtil {
         }
     }
 
-    fun show(activity: Activity) {
-        val inputMethodManager =
-            activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        activity.currentFocus?.let { view ->
-            inputMethodManager.showSoftInput(view, 0)
-        }
+    fun show(context: Context, view: View) {
+        view.requestFocus()
+        // open the soft keyboard
+        val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
     }
 }

--- a/data/src/main/java/com/photosurfer/android/data/remote/datasource/RemoteSearchTagResultDataSource.kt
+++ b/data/src/main/java/com/photosurfer/android/data/remote/datasource/RemoteSearchTagResultDataSource.kt
@@ -6,6 +6,6 @@ import com.photosurfer.android.data.remote.model.response.SearchTagResultRespons
 
 interface RemoteSearchTagResultDataSource {
 
-    suspend fun getSearchTagResultList(options: Map<String, Int>): NetworkState<BaseResponse<SearchTagResultResponse>>
+    suspend fun getSearchTagResultList(options: List<Pair<String, Int>>): NetworkState<BaseResponse<SearchTagResultResponse>>
 
 }

--- a/data/src/main/java/com/photosurfer/android/data/remote/datasource/RemoteSearchTagResultDataSourceImpl.kt
+++ b/data/src/main/java/com/photosurfer/android/data/remote/datasource/RemoteSearchTagResultDataSourceImpl.kt
@@ -11,7 +11,7 @@ class RemoteSearchTagResultDataSourceImpl @Inject constructor(
 ) : RemoteSearchTagResultDataSource {
 
     override suspend fun getSearchTagResultList(
-        options: Map<String, Int>
+        options: List<Pair<String, Int>>
     ): NetworkState<BaseResponse<SearchTagResultResponse>> =
         searchTagService.getSearchTagResultList(options)
 

--- a/data/src/main/java/com/photosurfer/android/data/remote/service/SearchTagResultService.kt
+++ b/data/src/main/java/com/photosurfer/android/data/remote/service/SearchTagResultService.kt
@@ -4,13 +4,13 @@ import com.photosurfer.android.data.remote.calladapter.NetworkState
 import com.photosurfer.android.data.remote.model.response.BaseResponse
 import com.photosurfer.android.data.remote.model.response.SearchTagResultResponse
 import retrofit2.http.GET
-import retrofit2.http.QueryMap
+import retrofit2.http.QueryName
 
 interface SearchTagResultService {
 
     @GET("photo/search/?")
     suspend fun getSearchTagResultList(
-        @QueryMap options: Map<String, Int>
+        @QueryName options: List<Pair<String, Int>>
     ): NetworkState<BaseResponse<SearchTagResultResponse>>
 
 }

--- a/data/src/main/java/com/photosurfer/android/data/repository/PhotoRepositoryImpl.kt
+++ b/data/src/main/java/com/photosurfer/android/data/repository/PhotoRepositoryImpl.kt
@@ -12,8 +12,8 @@ class PhotoRepositoryImpl @Inject constructor(
     private val remoteSearchTagResultDataSource: RemoteSearchTagResultDataSource
 ) : PhotoRepository {
 
-    override suspend fun getPhotoListByTag(options: Map<String, Int>): Result<SearchTagResult> {
-        val response = remoteSearchTagResultDataSource.getSearchTagResultList(options)
+    override suspend fun getPhotoListByTag(options: List<Pair<String, Int>>): Result<SearchTagResult> {
+        val response = remoteSearchTagResultDataSource.getSearchTagResultList(options.toList())
         when (response) {
             is NetworkState.Success -> {
                 val tags = response.body.data.tags

--- a/domain/src/main/java/com/photosurfer/android/domain/repository/PhotoRepository.kt
+++ b/domain/src/main/java/com/photosurfer/android/domain/repository/PhotoRepository.kt
@@ -4,6 +4,6 @@ import com.photosurfer.android.domain.entity.request.SearchTagResult
 
 interface PhotoRepository {
 
-    suspend fun getPhotoListByTag(options: Map<String, Int>): Result<SearchTagResult>
+    suspend fun getPhotoListByTag(options: List<Pair<String, Int>>): Result<SearchTagResult>
 
 }

--- a/feature/search-result/src/main/java/com/photosurfer/android/search_result/SearchResultActivity.kt
+++ b/feature/search-result/src/main/java/com/photosurfer/android/search_result/SearchResultActivity.kt
@@ -35,11 +35,11 @@ class SearchResultActivity :
 
         getExtraData()
         initExtraDataOnViewModel()
+        initChipAdapter()
         getNewPhotoAsTagChanged()
         updatePhoto()
         setDefaultViewType()
         setCancelListener()
-        initChipAdapter()
         setDataOnRecyclerView()
         initThumbnailAdapter()
         initThumbnailList()
@@ -57,7 +57,9 @@ class SearchResultActivity :
     }
 
     private fun getNewPhotoAsTagChanged() {
+        // TODO observe 작동 안함 deep copy 사용방법으로 교체
         viewModel.tagList.observe(this) {
+            Log.d(TAG, "getNewPhotoAsTagChanged: ${viewModel.tagList.value}")
             getPhotosByTags()
         }
     }
@@ -90,6 +92,7 @@ class SearchResultActivity :
     private fun deleteTag(position: Int) {
         viewModel.deleteTag(position)
         chipAdapter.notifyItemRemoved(position)
+        getPhotosByTags()
     }
 
     private fun setDataOnRecyclerView() {

--- a/feature/search-result/src/main/java/com/photosurfer/android/search_result/viewModel/SearchResultViewModel.kt
+++ b/feature/search-result/src/main/java/com/photosurfer/android/search_result/viewModel/SearchResultViewModel.kt
@@ -89,6 +89,7 @@ class SearchResultViewModel @Inject constructor(
 
     fun deleteTag(position: Int) {
         _tagList.value?.removeAt(position)
+        // _tagList.value = tagList.value?.toMutableList() // new Instance
         isTagListEmpty.value = tagList.value?.size == 0
     }
 

--- a/feature/search-result/src/main/java/com/photosurfer/android/search_result/viewModel/SearchResultViewModel.kt
+++ b/feature/search-result/src/main/java/com/photosurfer/android/search_result/viewModel/SearchResultViewModel.kt
@@ -69,8 +69,11 @@ class SearchResultViewModel @Inject constructor(
 
     fun getPhotosByTags() {
         viewModelScope.launch {
-            val option = mutableMapOf<String, Int>()
-            tagList.value?.forEach { option["id"] = it.id }
+            Log.d(TAG, "getPhotosByTags: ${tagList.value}")
+            val option = mutableListOf<Pair<String, Int>>()
+            tagList.value?.forEach { option.add(Pair("id", it.id)) }
+            Log.d(TAG, "getPhotosByTags: $option")
+            Log.d(TAG, "getPhotosByTags: $tagList")
             photoRepository.getPhotoListByTag(option)
                 .onSuccess {
                     _thumbnailList.value = it.photos.toMutableList()

--- a/feature/search/src/main/java/com/photosurfer/android/search/SearchTagFragment.kt
+++ b/feature/search/src/main/java/com/photosurfer/android/search/SearchTagFragment.kt
@@ -9,6 +9,7 @@ import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.photosurfer.android.core.base.BaseFragment
 import com.photosurfer.android.core.constant.SELECTED_TAG
+import com.photosurfer.android.core.util.KeyBoardUtil
 import com.photosurfer.android.core.util.PhotoSurferSnackBar
 import com.photosurfer.android.domain.entity.TagInfo
 import com.photosurfer.android.navigator.MainNavigator
@@ -35,6 +36,7 @@ class SearchTagFragment : BaseFragment<FragmentSearchTagBinding>(R.layout.fragme
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding.isTyping = true
 
+        setKeyBoardFocus()
         getRecommendTagList()
         setRecentList()
         setOftenList()
@@ -47,6 +49,10 @@ class SearchTagFragment : BaseFragment<FragmentSearchTagBinding>(R.layout.fragme
         setCompleteOnKeyBoardListener()
         deleteInput()
         initRecyclerViewLayout()
+    }
+
+    private fun setKeyBoardFocus() {
+        KeyBoardUtil.show(requireActivity(), binding.etTag)
     }
 
     private fun setPlatformList() {


### PR DESCRIPTION
## 관련 이슈번호
- #101 
- 
## 작업 설명
- 태그 정보로 이미지를 가져오는 api가 muti params으로 구성되는데, 기존에 map 자료구조를 사용했다
- id=1&id=2&id=3 으로 보냈어야 하는데, map을 사용하면 key 값이 중복이 안돼서 id=3의 params만 들어가졌다
- List<Pair> 형식을 사용해서 api를 수정함

- 태그 검색 뷰 EditText Focus 주기

## 작업화면(선택)

